### PR TITLE
chore(v1): send error to debug channel

### DIFF
--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1,6 +1,11 @@
 const client = require('../index');
+const { MessageEmbed } = require('discord.js');
 
 client.on('interactionCreate', async (interaction) => {
+  // Debug channel declarations
+  const debugChannel = client.channels.cache.find(
+    (channel) => channel.id === '899997057849393225'
+  );
   // Slash Command Handling
   if (interaction.isCommand()) {
     await interaction.deferReply({ ephemeral: false }).catch(() => {});
@@ -25,6 +30,12 @@ client.on('interactionCreate', async (interaction) => {
     try {
       cmd.run(client, interaction, args);
     } catch (err) {
+      const embed = new MessageEmbed()
+        .setTitle(':x: An Error Occured')
+        .setDescription(`\`\`\`yml\n${err}\n\`\`\``)
+        .setColor('RED')
+        .setTimestamp();
+      debugChannel.send({ embeds: [embed] });
       console.log(err);
     }
   }


### PR DESCRIPTION
## What I'm doing in this Pull Request
- [x] Update code

## Description
Send and suppress `interactionCreate` events error to Debug Channel at Discord.

## Why this Pull Request is valuable (or not)
Since `Discord.js@13.0.0` is released, When you have an error, It will throw an error. And it's annoying. Makes the bot crashing for simple error. This Pull Request wrapping Run code into Try-catch block. And if there's any errors, It'll sent to Debug channel. And the bots keep alive. That's it!